### PR TITLE
Resolve errors from type checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,35 +11,10 @@ env:
 
 matrix:
   include:
-    - python: '3.5'
-      env:
-        - TOXENV=du13
-    - python: '3.6'
-      env:
-        - TOXENV=py36
-        - PYTEST_ADDOPTS="--cov ./ --cov-append --cov-config setup.cfg"
-    - python: '3.7'
-      env: TOXENV=py37
-      dist: xenial
-      sudo: true
-    - python: 'nightly'
-      env: TOXENV=py38
-      dist: xenial
-      sudo: true
-    - python: '3.6'
-      env: TOXENV=docs
     - python: '3.6'
       env: TOXENV=mypy
     - python: '3.6'
       env: TOXENV=flake8
-
-    - language: node_js
-      node_js:
-        - 10.7
-      env: IS_PYTHON=false
-      before_script:
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start
 
 install:
   - if [ $IS_PYTHON = true ]; then pip install -U tox codecov; fi

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ extras_require = {
         'flake8-import-order',
         'mypy',
         'typed_ast',
+        'docutils-stubs',
     ],
 }
 

--- a/sphinx/application.py
+++ b/sphinx/application.py
@@ -276,10 +276,10 @@ class Sphinx:
                     user_locale_dirs, self.config.language, domains=['sphinx'],
                     charset=self.config.source_encoding):
                 catinfo.write_mo(self.config.language)
-            locale_dirs = [None, path.join(package_dir, 'locale')] + user_locale_dirs  # type: ignore  # NOQA
+            locale_dirs = [None, path.join(package_dir, 'locale')] + user_locale_dirs
         else:
             locale_dirs = []
-        self.translator, has_translation = locale.init(locale_dirs, self.config.language)  # type: ignore  # NOQA
+        self.translator, has_translation = locale.init(locale_dirs, self.config.language)
         if self.config.language is not None:
             if has_translation or self.config.language == 'en':
                 # "en" never needs to be translated

--- a/sphinx/builders/changes.py
+++ b/sphinx/builders/changes.py
@@ -112,11 +112,9 @@ class ChangesBuilder(Builder):
             'show_copyright': self.config.html_show_copyright,
             'show_sphinx': self.config.html_show_sphinx,
         }
-        with open(path.join(self.outdir, 'index.html'), 'w',  # type: ignore
-                  encoding='utf8') as f:
+        with open(path.join(self.outdir, 'index.html'), 'w', encoding='utf8') as f:
             f.write(self.templates.render('changes/frameset.html', ctx))
-        with open(path.join(self.outdir, 'changes.html'), 'w',  # type: ignore
-                  encoding='utf8') as f:
+        with open(path.join(self.outdir, 'changes.html'), 'w', encoding='utf8') as f:
             f.write(self.templates.render('changes/versionchanges.html', ctx))
 
         hltext = ['.. versionadded:: %s' % version,
@@ -134,7 +132,7 @@ class ChangesBuilder(Builder):
 
         logger.info(bold(__('copying source files...')))
         for docname in self.env.all_docs:
-            with open(self.env.doc2path(docname), 'r',  # type: ignore
+            with open(self.env.doc2path(docname), 'r',
                       encoding=self.env.config.source_encoding) as f:
                 try:
                     lines = f.readlines()
@@ -143,7 +141,7 @@ class ChangesBuilder(Builder):
                     continue
             targetfn = path.join(self.outdir, 'rst', os_path(docname)) + '.html'
             ensuredir(path.dirname(targetfn))
-            with open(targetfn, 'w', encoding='utf-8') as f:  # type: ignore
+            with open(targetfn, 'w', encoding='utf-8') as f:
                 text = ''.join(hl(i + 1, line) for (i, line) in enumerate(lines))
                 ctx = {
                     'filename': self.env.doc2path(docname, None),

--- a/sphinx/builders/gettext.py
+++ b/sphinx/builders/gettext.py
@@ -198,7 +198,7 @@ def should_write(filepath, new_content):
     if not path.exists(filepath):
         return True
     try:
-        with open(filepath, 'r', encoding='utf-8') as oldpot:  # type: ignore
+        with open(filepath, 'r', encoding='utf-8') as oldpot:
             old_content = oldpot.read()
             old_header_index = old_content.index('"POT-Creation-Date:')
             new_header_index = new_content.index('"POT-Creation-Date:')
@@ -246,7 +246,7 @@ class MessageCatalogBuilder(I18nBuilder):
 
         extract_translations = self.templates.environment.extract_translations
 
-        for template in status_iterator(files, __('reading templates... '), "purple",  # type: ignore  # NOQA
+        for template in status_iterator(files, __('reading templates... '), "purple",
                                         len(files), self.app.verbosity):
             try:
                 with open(template, 'r', encoding='utf-8') as f:  # type: ignore
@@ -272,7 +272,7 @@ class MessageCatalogBuilder(I18nBuilder):
             ctime = datetime.fromtimestamp(
                 timestamp, ltz).strftime('%Y-%m-%d %H:%M%z'),
         )
-        for textdomain, catalog in status_iterator(self.catalogs.items(),  # type: ignore
+        for textdomain, catalog in status_iterator(self.catalogs.items(),
                                                    __("writing message catalogs... "),
                                                    "darkgreen", len(self.catalogs),
                                                    self.app.verbosity,
@@ -282,31 +282,31 @@ class MessageCatalogBuilder(I18nBuilder):
 
             pofn = path.join(self.outdir, textdomain + '.pot')
             output = StringIO()
-            output.write(POHEADER % data)  # type: ignore
+            output.write(POHEADER % data)
 
             for message in catalog.messages:
                 positions = catalog.metadata[message]
 
                 if self.config.gettext_location:
                     # generate "#: file1:line1\n#: file2:line2 ..."
-                    output.write("#: %s\n" % "\n#: ".join(  # type: ignore
+                    output.write("#: %s\n" % "\n#: ".join(
                         "%s:%s" % (canon_path(relpath(source, self.outdir)), line)
                         for source, line, _ in positions))
                 if self.config.gettext_uuid:
                     # generate "# uuid1\n# uuid2\n ..."
-                    output.write("# %s\n" % "\n# ".join(  # type: ignore
+                    output.write("# %s\n" % "\n# ".join(
                         uid for _, _, uid in positions))
 
                 # message contains *one* line of text ready for translation
                 message = message.replace('\\', r'\\'). \
                     replace('"', r'\"'). \
                     replace('\n', '\\n"\n"')
-                output.write('msgid "%s"\nmsgstr ""\n\n' % message)  # type: ignore
+                output.write('msgid "%s"\nmsgstr ""\n\n' % message)
 
             content = output.getvalue()
 
             if should_write(pofn, content):
-                with open(pofn, 'w', encoding='utf-8') as pofile:  # type: ignore
+                with open(pofn, 'w', encoding='utf-8') as pofile:
                     pofile.write(content)
 
 

--- a/sphinx/cmdline.py
+++ b/sphinx/cmdline.py
@@ -45,7 +45,7 @@ def get_parser():
     return build.get_parser()
 
 
-def main(argv=sys.argv[1:]):  # type: ignore
+def main(argv=sys.argv[1:]):
     # type: (List[str]) -> int
     warnings.warn('sphinx.cmdline module is deprecated. Use sphinx.cmd.build instead.',
                   RemovedInSphinx30Warning, stacklevel=2)

--- a/sphinx/config.py
+++ b/sphinx/config.py
@@ -272,7 +272,7 @@ class Config:
                 logger.warning("%s", exc)
         for name in config:
             if name in self.values:
-                self.__dict__[name] = config[name]  # type: ignore
+                self.__dict__[name] = config[name]
 
     def __getattr__(self, name):
         # type: (str) -> Any
@@ -304,7 +304,7 @@ class Config:
     def __iter__(self):
         # type: () -> Generator[ConfigValue, None, None]
         for name, value in self.values.items():
-            yield ConfigValue(name, getattr(self, name), value[1])  # type: ignore
+            yield ConfigValue(name, getattr(self, name), value[1])
 
     def add(self, name, default, rebuild, types):
         # type: (str, Any, Union[bool, str], Any) -> None
@@ -332,7 +332,7 @@ class Config:
 
         # create a picklable copy of values list
         __dict__['values'] = {}
-        for key, value in self.values.items():  # type: ignore
+        for key, value in self.values.items():
             real_value = getattr(self, key)
             if not is_serializable(real_value):
                 # omit unserializable value

--- a/sphinx/ext/autodoc/__init__.py
+++ b/sphinx/ext/autodoc/__init__.py
@@ -314,7 +314,7 @@ class Documenter:
             modname = None
             parents = []
 
-        self.modname, self.objpath = self.resolve_name(modname, parents, path, base)  # type: ignore  # NOQA
+        self.modname, self.objpath = self.resolve_name(modname, parents, path, base)
 
         if not self.modname:
             return False
@@ -907,7 +907,7 @@ class ClassLevelDocumenter(Documenter):
                 # ... if still None, there's no way to know
                 if mod_cls is None:
                     return None, []
-            modname, cls = rpartition(mod_cls, '.')  # type: ignore
+            modname, cls = rpartition(mod_cls, '.')
             parents = [cls]
             # if the module name is still missing, get it like above
             if not modname:
@@ -951,7 +951,7 @@ class DocstringSignatureMixin:
             result = args, retann
             # don't look any further
             break
-        return result  # type: ignore
+        return result
 
     def get_doc(self, encoding=None, ignore=1):
         # type: (str, int) -> List[List[str]]

--- a/sphinx/ext/doctest.py
+++ b/sphinx/ext/doctest.py
@@ -494,8 +494,7 @@ Doctest summary
             # type: (Any, List[TestCode], Any) -> bool
             examples = []
             for testcode in testcodes:
-                example = doctest.Example(testcode.code, '',  # type: ignore
-                                          lineno=testcode.lineno)
+                example = doctest.Example(testcode.code, '', lineno=testcode.lineno)
                 examples.append(example)
             if not examples:
                 return True
@@ -547,11 +546,11 @@ Doctest summary
                     exc_msg = m.group('msg')
                 else:
                     exc_msg = None
-                example = doctest.Example(code[0].code, output,  # type: ignore
+                example = doctest.Example(code[0].code, output,
                                           exc_msg=exc_msg,
                                           lineno=code[0].lineno,
                                           options=options)
-                test = doctest.DocTest([example], {}, group.name,  # type: ignore
+                test = doctest.DocTest([example], {}, group.name,
                                        code[0].filename, code[0].lineno, None)
                 self.type = 'exec'  # multiple statements again
             # DocTest.__init__ copies the globs namespace, which we don't want

--- a/sphinx/ext/graphviz.py
+++ b/sphinx/ext/graphviz.py
@@ -141,7 +141,7 @@ class Graphviz(SphinxDirective):
             rel_filename, filename = self.env.relfn2path(argument)
             self.env.note_dependency(rel_filename)
             try:
-                with open(filename, 'r', encoding='utf-8') as fp:  # type: ignore
+                with open(filename, 'r', encoding='utf-8') as fp:
                     dotcode = fp.read()
             except (IOError, OSError):
                 return [document.reporter.warning(

--- a/sphinx/ext/inheritance_diagram.py
+++ b/sphinx/ext/inheritance_diagram.py
@@ -75,7 +75,7 @@ def try_import(objname):
     """
     try:
         __import__(objname)
-        return sys.modules.get(objname)  # type: ignore
+        return sys.modules.get(objname)
     except (ImportError, ValueError):  # ValueError,py27 -> ImportError,py3
         matched = module_sig_re.match(objname)
 
@@ -88,7 +88,7 @@ def try_import(objname):
             return None
         try:
             __import__(modname)
-            return getattr(sys.modules.get(modname), attrname, None)  # type: ignore
+            return getattr(sys.modules.get(modname), attrname, None)
         except (ImportError, ValueError):  # ValueError,py27 -> ImportError,py3
             return None
 

--- a/sphinx/highlighting.py
+++ b/sphinx/highlighting.py
@@ -95,7 +95,7 @@ class PygmentsBridge:
 
     def get_formatter(self, **kwargs):
         # type: (Any) -> Formatter
-        kwargs.update(self.formatter_args)  # type: ignore
+        kwargs.update(self.formatter_args)
         return self.formatter(**kwargs)
 
     def unhighlighted(self, source):

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -22,7 +22,7 @@ from sphinx.deprecation import RemovedInSphinx30Warning
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, Iterator, List, Tuple  # NOQA
+    from typing import Any, Callable, Dict, Iterator, List, Tuple, Union  # NOQA
 
 
 class _TranslationProxy(UserString):
@@ -47,7 +47,7 @@ class _TranslationProxy(UserString):
         return object.__new__(cls)
 
     def __getnewargs__(self):
-        # type: () -> Tuple
+        # type: () -> Tuple[str]
         return (self._func,) + self._args  # type: ignore
 
     def __init__(self, func, *args):
@@ -127,11 +127,11 @@ class _TranslationProxy(UserString):
         return other * self.data
 
     def __lt__(self, other):
-        # type: (str) -> bool
+        # type: (Union[str, UserString]) -> bool
         return self.data < other
 
     def __le__(self, other):
-        # type: (str) -> bool
+        # type: (Union[str, UserString]) -> bool
         return self.data <= other
 
     def __eq__(self, other):
@@ -139,11 +139,11 @@ class _TranslationProxy(UserString):
         return self.data == other
 
     def __gt__(self, other):
-        # type: (str) -> bool
+        # type: (Union[str, UserString]) -> bool
         return self.data > other
 
     def __ge__(self, other):
-        # type: (str) -> bool
+        # type: (Union[str, UserString]) -> bool
         return self.data >= other
 
     def __getattr__(self, name):

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -223,8 +223,7 @@ def init(locale_dirs, language, catalog='sphinx', namespace='general'):
     # loading
     for dir_ in locale_dirs:
         try:
-            trans = gettext.translation(catalog, localedir=dir_,
-                                        languages=languages)
+            trans = gettext.translation(catalog, localedir=dir_, languages=languages)
             if translator is None:
                 translator = trans
             else:

--- a/sphinx/locale/__init__.py
+++ b/sphinx/locale/__init__.py
@@ -106,7 +106,7 @@ class _TranslationProxy(UserString):
         # type: (str) -> str
         return self.data + other
 
-    def __radd__(self, other):  # type: ignore
+    def __radd__(self, other):
         # type: (str) -> str
         return other + self.data
 
@@ -122,7 +122,7 @@ class _TranslationProxy(UserString):
         # type: (Any) -> str
         return self.data * other
 
-    def __rmul__(self, other):  # type: ignore
+    def __rmul__(self, other):
         # type: (Any) -> str
         return other * self.data
 
@@ -223,7 +223,7 @@ def init(locale_dirs, language, catalog='sphinx', namespace='general'):
     # loading
     for dir_ in locale_dirs:
         try:
-            trans = gettext.translation(catalog, localedir=dir_,  # type: ignore
+            trans = gettext.translation(catalog, localedir=dir_,
                                         languages=languages)
             if translator is None:
                 translator = trans
@@ -274,7 +274,7 @@ def _lazy_translate(catalog, namespace, message):
     not bound yet at that time.
     """
     translator = get_translator(catalog, namespace)
-    return translator.gettext(message)  # type: ignore
+    return translator.gettext(message)
 
 
 def get_translation(catalog, namespace='general'):
@@ -309,9 +309,9 @@ def get_translation(catalog, namespace='general'):
         else:
             translator = get_translator(catalog, namespace)
             if len(args) <= 1:
-                return translator.gettext(message)  # type: ignore
+                return translator.gettext(message)
             else:  # support pluralization
-                return translator.ngettext(message, args[0], args[1])  # type: ignore
+                return translator.ngettext(message, args[0], args[1])
 
     return gettext
 

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -49,7 +49,7 @@ def get_assign_targets(node):
 
 
 def get_lvar_names(node, self=None):
-    # type: (ast.AST, ast.expr) -> List[str]
+    # type: (ast.AST, ast.arg) -> List[str]
     """Convert assignment-AST to variable names.
 
     This raises `TypeError` if the assignment does not create new variable::
@@ -59,7 +59,7 @@ def get_lvar_names(node, self=None):
         # => TypeError
     """
     if self:
-        self_id = self.arg  # type: ignore
+        self_id = self.arg
 
     node_name = node.__class__.__name__
     if node_name in ('Index', 'Num', 'Slice', 'Str', 'Subscript'):
@@ -278,7 +278,7 @@ class VariableCommentPicker(ast.NodeVisitor):
         self.comments[(context, name)] = comment
 
     def get_self(self):
-        # type: () -> ast.expr
+        # type: () -> ast.arg
         """Returns the name of first argument if in function."""
         if self.current_function and self.current_function.args.args:
             return self.current_function.args.args[0]

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -99,7 +99,7 @@ def dedent_docstring(s):
         # dummy function to mock `inspect.getdoc`.
         pass
 
-    dummy.__doc__ = s  # type: ignore
+    dummy.__doc__ = s
     docstring = inspect.getdoc(dummy)
     return docstring.lstrip("\r\n").rstrip("\r\n")
 
@@ -143,7 +143,7 @@ class TokenProcessor:
         # type: (List[str]) -> None
         lines = iter(buffers)
         self.buffers = buffers
-        self.tokens = tokenize.generate_tokens(lambda: next(lines))  # type: ignore  # NOQA
+        self.tokens = tokenize.generate_tokens(lambda: next(lines))
         self.current = None     # type: Token
         self.previous = None    # type: Token
 

--- a/sphinx/registry.py
+++ b/sphinx/registry.py
@@ -237,7 +237,7 @@ class SphinxComponentRegistry:
                       ref_nodeclass, objname, doc_field_types))
 
         # create a subclass of GenericObject as the new directive
-        directive = type(directivename,  # type: ignore
+        directive = type(directivename,
                          (GenericObject, object),
                          {'indextemplate': indextemplate,
                           'parse_node': staticmethod(parse_node),
@@ -259,7 +259,7 @@ class SphinxComponentRegistry:
                      (directivename, rolename, indextemplate, ref_nodeclass, objname))
 
         # create a subclass of Target as the new directive
-        directive = type(directivename,  # type: ignore
+        directive = type(directivename,
                          (Target, object),
                          {'indextemplate': indextemplate})
 
@@ -430,7 +430,7 @@ class SphinxComponentRegistry:
     def add_js_file(self, filename, **attributes):
         # type: (str, **str) -> None
         logger.debug('[app] adding js_file: %r, %r', filename, attributes)
-        self.js_files.append((filename, attributes))  # type: ignore
+        self.js_files.append((filename, attributes))
 
     def add_latex_package(self, name, options):
         # type: (str, str) -> None

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -26,7 +26,7 @@ if False:
     from docutils.parsers.rst.states import Inliner  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
-
+    from sphinx.util.typing import RoleFunction  # NOQA
 
 generic_docroles = {
     'command': addnodes.literal_strong,
@@ -395,7 +395,7 @@ specific_docroles = {
     'samp': emph_literal_role,
     'abbr': abbr_role,
     'index': index_role,
-}  # type: Dict[str, Callable[[str, str, str, int, Inliner, Dict, List[str]], Tuple[List[nodes.Node], List[nodes.Node]]]]  # NOQA
+}  # type: Dict[str, RoleFunction]
 
 
 def setup(app):

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -99,7 +99,7 @@ class XRefRole:
     def __call__(self, typ, rawtext, text, lineno, inliner,
                  options={}, content=[]):
         # type: (str, str, str, int, Inliner, Dict, List[str]) -> Tuple[List[nodes.Node], List[nodes.Node]]  # NOQA
-        env = inliner.document.settings.env
+        env = inliner.document.settings.env  # type: ignore
         if not typ:
             typ = env.temp_data.get('default_role')
             if not typ:
@@ -120,7 +120,7 @@ class XRefRole:
             if self.fix_parens:
                 text, tgt = self._fix_parens(env, False, text, "")
             innernode = self.innernodeclass(rawtext, text, classes=classes)
-            return self.result_nodes(inliner.document, env, innernode,
+            return self.result_nodes(inliner.document, env, innernode,  # type: ignore
                                      is_ref=False)
         # split title and target in role content
         has_explicit_title, title, target = split_explicit_title(text)
@@ -146,7 +146,7 @@ class XRefRole:
         refnode['refdoc'] = env.docname
         refnode['refwarn'] = self.warn_dangling
         # result_nodes allow further modification of return values
-        return self.result_nodes(inliner.document, env, refnode, is_ref=True)
+        return self.result_nodes(inliner.document, env, refnode, is_ref=True)  # type: ignore
 
     # methods that can be overwritten
 
@@ -175,14 +175,14 @@ class AnyXRefRole(XRefRole):
         result = XRefRole.process_link(self, env, refnode, has_explicit_title,
                                        title, target)
         # add all possible context info (i.e. std:program, py:module etc.)
-        refnode.attributes.update(env.ref_context)
+        refnode.attributes.update(env.ref_context)  # type: ignore
         return result
 
 
 def indexmarkup_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     # type: (str, str, str, int, Inliner, Dict, List[str]) -> Tuple[List[nodes.Node], List[nodes.Node]]  # NOQA
     """Role for PEP/RFC references that generate an index entry."""
-    env = inliner.document.settings.env
+    env = inliner.document.settings.env  # type: ignore
     if not typ:
         assert env.temp_data['default_role']
         typ = env.temp_data['default_role'].lower()
@@ -195,7 +195,7 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner, options={}, content=[]
     targetid = 'index-%s' % env.new_serialno('index')
     indexnode = addnodes.index()
     targetnode = nodes.target('', '', ids=[targetid])
-    inliner.document.note_explicit_target(targetnode)
+    inliner.document.note_explicit_target(targetnode)  # type: ignore
     if typ == 'pep':
         indexnode['entries'] = [
             ('single', _('Python Enhancement Proposals; PEP %s') % target,
@@ -209,11 +209,11 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner, options={}, content=[]
         try:
             pepnum = int(target)
         except ValueError:
-            msg = inliner.reporter.error('invalid PEP number %s' % target,
+            msg = inliner.reporter.error('invalid PEP number %s' % target,  # type: ignore
                                          line=lineno)
-            prb = inliner.problematic(rawtext, rawtext, msg)
+            prb = inliner.problematic(rawtext, rawtext, msg)  # type: ignore
             return [prb], [msg]
-        ref = inliner.document.settings.pep_base_url + 'pep-%04d' % pepnum
+        ref = inliner.document.settings.pep_base_url + 'pep-%04d' % pepnum  # type: ignore
         sn = nodes.strong(title, title)
         rn = nodes.reference('', '', internal=False, refuri=ref + anchor,
                              classes=[typ])
@@ -231,11 +231,11 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner, options={}, content=[]
         try:
             rfcnum = int(target)
         except ValueError:
-            msg = inliner.reporter.error('invalid RFC number %s' % target,
+            msg = inliner.reporter.error('invalid RFC number %s' % target,  # type: ignore
                                          line=lineno)
-            prb = inliner.problematic(rawtext, rawtext, msg)
+            prb = inliner.problematic(rawtext, rawtext, msg)  # type: ignore
             return [prb], [msg]
-        ref = inliner.document.settings.rfc_base_url + inliner.rfc_url % rfcnum
+        ref = inliner.document.settings.rfc_base_url + inliner.rfc_url % rfcnum  # type: ignore
         sn = nodes.strong(title, title)
         rn = nodes.reference('', '', internal=False, refuri=ref + anchor,
                              classes=[typ])
@@ -250,7 +250,7 @@ _amp_re = re.compile(r'(?<!&)&(?![&\s])')
 
 def menusel_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     # type: (str, str, str, int, Inliner, Dict, List[str]) -> Tuple[List[nodes.Node], List[nodes.Node]]  # NOQA
-    env = inliner.document.settings.env
+    env = inliner.document.settings.env  # type: ignore
     if not typ:
         assert env.temp_data['default_role']
         typ = env.temp_data['default_role'].lower()
@@ -289,7 +289,7 @@ parens_re = re.compile(r'(\\*{|\\*})')
 def emph_literal_role(typ, rawtext, text, lineno, inliner,
                       options={}, content=[]):
     # type: (str, str, str, int, Inliner, Dict, List[str]) -> Tuple[List[nodes.Node], List[nodes.Node]]  # NOQA
-    env = inliner.document.settings.env
+    env = inliner.document.settings.env  # type: ignore
     if not typ:
         assert env.temp_data['default_role']
         typ = env.temp_data['default_role'].lower()
@@ -355,7 +355,7 @@ def abbr_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
 def index_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     # type: (str, str, str, int, Inliner, Dict, List[str]) -> Tuple[List[nodes.Node], List[nodes.Node]]  # NOQA
     # create new reference target
-    env = inliner.document.settings.env
+    env = inliner.document.settings.env  # type: ignore
     targetid = 'index-%s' % env.new_serialno('index')
     targetnode = nodes.target('', '', ids=[targetid])
     # split text and target in role content

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -120,8 +120,7 @@ class XRefRole:
             if self.fix_parens:
                 text, tgt = self._fix_parens(env, False, text, "")
             innernode = self.innernodeclass(rawtext, text, classes=classes)
-            return self.result_nodes(inliner.document, env, innernode,  # type: ignore
-                                     is_ref=False)
+            return self.result_nodes(inliner.document, env, innernode, is_ref=False)
         # split title and target in role content
         has_explicit_title, title, target = split_explicit_title(text)
         title = utils.unescape(title)
@@ -146,7 +145,7 @@ class XRefRole:
         refnode['refdoc'] = env.docname
         refnode['refwarn'] = self.warn_dangling
         # result_nodes allow further modification of return values
-        return self.result_nodes(inliner.document, env, refnode, is_ref=True)  # type: ignore
+        return self.result_nodes(inliner.document, env, refnode, is_ref=True)
 
     # methods that can be overwritten
 
@@ -175,7 +174,7 @@ class AnyXRefRole(XRefRole):
         result = XRefRole.process_link(self, env, refnode, has_explicit_title,
                                        title, target)
         # add all possible context info (i.e. std:program, py:module etc.)
-        refnode.attributes.update(env.ref_context)  # type: ignore
+        refnode.attributes.update(env.ref_context)
         return result
 
 
@@ -195,7 +194,7 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner, options={}, content=[]
     targetid = 'index-%s' % env.new_serialno('index')
     indexnode = addnodes.index()
     targetnode = nodes.target('', '', ids=[targetid])
-    inliner.document.note_explicit_target(targetnode)  # type: ignore
+    inliner.document.note_explicit_target(targetnode)
     if typ == 'pep':
         indexnode['entries'] = [
             ('single', _('Python Enhancement Proposals; PEP %s') % target,
@@ -209,9 +208,8 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner, options={}, content=[]
         try:
             pepnum = int(target)
         except ValueError:
-            msg = inliner.reporter.error('invalid PEP number %s' % target,  # type: ignore
-                                         line=lineno)
-            prb = inliner.problematic(rawtext, rawtext, msg)  # type: ignore
+            msg = inliner.reporter.error('invalid PEP number %s' % target, line=lineno)
+            prb = inliner.problematic(rawtext, rawtext, msg)
             return [prb], [msg]
         ref = inliner.document.settings.pep_base_url + 'pep-%04d' % pepnum  # type: ignore
         sn = nodes.strong(title, title)
@@ -231,9 +229,8 @@ def indexmarkup_role(typ, rawtext, text, lineno, inliner, options={}, content=[]
         try:
             rfcnum = int(target)
         except ValueError:
-            msg = inliner.reporter.error('invalid RFC number %s' % target,  # type: ignore
-                                         line=lineno)
-            prb = inliner.problematic(rawtext, rawtext, msg)  # type: ignore
+            msg = inliner.reporter.error('invalid RFC number %s' % target, line=lineno)
+            prb = inliner.problematic(rawtext, rawtext, msg)
             return [prb], [msg]
         ref = inliner.document.settings.rfc_base_url + inliner.rfc_url % rfcnum  # type: ignore
         sn = nodes.strong(title, title)

--- a/sphinx/roles.py
+++ b/sphinx/roles.py
@@ -22,7 +22,7 @@ from sphinx.util.nodes import split_explicit_title, process_index_entry, \
 
 if False:
     # For type annotation
-    from typing import Any, Dict, List, Tuple, Type  # NOQA
+    from typing import Any, Callable, Dict, List, Tuple, Type  # NOQA
     from docutils.parsers.rst.states import Inliner  # NOQA
     from sphinx.application import Sphinx  # NOQA
     from sphinx.environment import BuildEnvironment  # NOQA
@@ -395,7 +395,7 @@ specific_docroles = {
     'samp': emph_literal_role,
     'abbr': abbr_role,
     'index': index_role,
-}
+}  # type: Dict[str, Callable[[str, str, str, int, Inliner, Dict, List[str]], Tuple[List[nodes.Node], List[nodes.Node]]]]  # NOQA
 
 
 def setup(app):

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -165,7 +165,7 @@ class path(text_type):
             return f.read()
 
     def bytes(self):
-        # type: () -> str
+        # type: () -> __builtins__.bytes
         """
         Returns the bytes in the file.
         """

--- a/sphinx/testing/path.py
+++ b/sphinx/testing/path.py
@@ -153,7 +153,7 @@ class path(text_type):
         """
         if isinstance(text, bytes):
             text = text.decode(encoding)
-        with open(self, 'w', encoding=encoding, **kwargs) as f:  # type: ignore
+        with open(self, 'w', encoding=encoding, **kwargs) as f:
             f.write(text)
 
     def text(self, encoding='utf-8', **kwargs):
@@ -161,7 +161,7 @@ class path(text_type):
         """
         Returns the text in the file.
         """
-        with open(self, mode='r', encoding=encoding, **kwargs) as f:  # type: ignore
+        with open(self, mode='r', encoding=encoding, **kwargs) as f:
             return f.read()
 
     def bytes(self):

--- a/sphinx/transforms/i18n.py
+++ b/sphinx/transforms/i18n.py
@@ -104,7 +104,7 @@ class Locale(SphinxTransform):
 
         # phase1: replace reference ids with translated names
         for node, msg in extract_messages(self.document):
-            msgstr = catalog.gettext(msg)  # type: ignore
+            msgstr = catalog.gettext(msg)
             # XXX add marker to untranslated parts
             if not msgstr or msgstr == msg or not msgstr.strip():
                 # as-of-yet untranslated
@@ -218,7 +218,7 @@ class Locale(SphinxTransform):
             if node.get('translated', False):  # to avoid double translation
                 continue  # skip if the node is already translated by phase1
 
-            msgstr = catalog.gettext(msg)  # type: ignore
+            msgstr = catalog.gettext(msg)
             # XXX add marker to untranslated parts
             if not msgstr or msgstr == msg:  # as-of-yet untranslated
                 continue
@@ -450,7 +450,7 @@ class Locale(SphinxTransform):
                     msg_parts = split_index_msg(type, msg)
                     msgstr_parts = []
                     for part in msg_parts:
-                        msgstr = catalog.gettext(part)  # type: ignore
+                        msgstr = catalog.gettext(part)
                         if not msgstr:
                             msgstr = part
                         msgstr_parts.append(msgstr)

--- a/sphinx/util/__init__.py
+++ b/sphinx/util/__init__.py
@@ -258,7 +258,7 @@ def save_traceback(app):
     last_msgs = ''
     if app is not None:
         last_msgs = '\n'.join(
-            '#   %s' % strip_colors(force_decode(s, 'utf-8')).strip()  # type: ignore
+            '#   %s' % strip_colors(force_decode(s, 'utf-8')).strip()
             for s in app.messagelog)
     os.write(fd, (_DEBUG_HEADER %
                   (sphinx.__display_version__,

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -368,5 +368,3 @@ def new_document(source_path, settings=None):
     document = nodes.document(settings, __document_cache__.reporter, source=source_path)
     document.note_source(source_path, -1)
     return document
-
-

--- a/sphinx/util/docutils.py
+++ b/sphinx/util/docutils.py
@@ -125,7 +125,7 @@ def using_user_docutils_conf(confdir):
     try:
         docutilsconfig = os.environ.get('DOCUTILSCONFIG', None)
         if confdir:
-            os.environ['DOCUTILSCONFIG'] = path.join(path.abspath(confdir), 'docutils.conf')  # type: ignore  # NOQA
+            os.environ['DOCUTILSCONFIG'] = path.join(path.abspath(confdir), 'docutils.conf')
 
         yield
     finally:
@@ -231,7 +231,7 @@ class WarningStream:
         else:
             location, type, level = matched.groups()
             message = report_re.sub('', text).rstrip()
-            logger.log(type, message, location=location)  # type: ignore
+            logger.log(type, message, location=location)
 
 
 class LoggingReporter(Reporter):
@@ -313,7 +313,7 @@ class SphinxFileOutput(FileOutput):
         # type: (str) -> str
         if (self.destination_path and self.autoclose and 'b' not in self.mode and
                 self.overwrite_if_changed and os.path.exists(self.destination_path)):
-            with open(self.destination_path, encoding=self.encoding) as f:  # type: ignore
+            with open(self.destination_path, encoding=self.encoding) as f:
                 # skip writing: content not changed
                 if f.read() == data:
                     return data

--- a/sphinx/util/fileutil.py
+++ b/sphinx/util/fileutil.py
@@ -48,10 +48,10 @@ def copy_asset_file(source, destination, context=None, renderer=None):
             from sphinx.util.template import SphinxRenderer
             renderer = SphinxRenderer()
 
-        with open(source, 'r', encoding='utf-8') as fsrc:  # type: ignore
+        with open(source, 'r', encoding='utf-8') as fsrc:
             if destination.lower().endswith('_t'):
                 destination = destination[:-2]
-            with open(destination, 'w', encoding='utf-8') as fdst:  # type: ignore
+            with open(destination, 'w', encoding='utf-8') as fdst:
                 fdst.write(renderer.render_string(fsrc.read(), context))
     else:
         copyfile(source, destination)

--- a/sphinx/util/i18n.py
+++ b/sphinx/util/i18n.py
@@ -68,7 +68,7 @@ class CatalogInfo(LocaleFileInfoBase):
 
     def write_mo(self, locale):
         # type: (str) -> None
-        with open(self.po_path, 'rt', encoding=self.charset) as file_po:  # type: ignore
+        with open(self.po_path, 'rt', encoding=self.charset) as file_po:
             try:
                 po = read_po(file_po, locale)
             except Exception as exc:
@@ -98,10 +98,10 @@ def find_catalog_files(docname, srcdir, locale_dirs, lang, compaction):
         return []
 
     domain = find_catalog(docname, compaction)
-    files = [gettext.find(domain, path.join(srcdir, dir_), [lang])  # type: ignore
+    files = [gettext.find(domain, path.join(srcdir, dir_), [lang])
              for dir_ in locale_dirs]
-    files = [relpath(f, srcdir) for f in files if f]  # type: ignore
-    return files  # type: ignore
+    files = [relpath(f, srcdir) for f in files if f]
+    return files
 
 
 def find_catalog_source_files(locale_dirs, locale, domains=None, gettext_compact=None,

--- a/sphinx/util/images.py
+++ b/sphinx/util/images.py
@@ -139,4 +139,4 @@ def test_svg(h, f):
 
 # install test_svg() to imghdr
 # refs: https://docs.python.org/3.6/library/imghdr.html#imghdr.tests
-imghdr.tests.append(test_svg)  # type: ignore
+imghdr.tests.append(test_svg)

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -54,7 +54,7 @@ def getargspec(func):
         raise TypeError(
             "can't compute signature for built-in type {}".format(func))
 
-    sig = inspect.signature(func)  # type: ignore
+    sig = inspect.signature(func)
 
     args = []
     varargs = None
@@ -72,19 +72,19 @@ def getargspec(func):
         kind = param.kind
         name = param.name
 
-        if kind is inspect.Parameter.POSITIONAL_ONLY:  # type: ignore
+        if kind is inspect.Parameter.POSITIONAL_ONLY:
             args.append(name)
-        elif kind is inspect.Parameter.POSITIONAL_OR_KEYWORD:  # type: ignore
+        elif kind is inspect.Parameter.POSITIONAL_OR_KEYWORD:
             args.append(name)
             if param.default is not param.empty:
                 defaults += (param.default,)  # type: ignore
-        elif kind is inspect.Parameter.VAR_POSITIONAL:  # type: ignore
+        elif kind is inspect.Parameter.VAR_POSITIONAL:
             varargs = name
-        elif kind is inspect.Parameter.KEYWORD_ONLY:  # type: ignore
+        elif kind is inspect.Parameter.KEYWORD_ONLY:
             kwonlyargs.append(name)
             if param.default is not param.empty:
                 kwdefaults[name] = param.default
-        elif kind is inspect.Parameter.VAR_KEYWORD:  # type: ignore
+        elif kind is inspect.Parameter.VAR_KEYWORD:
             varkw = name
 
         if param.annotation is not param.empty:
@@ -98,7 +98,7 @@ def getargspec(func):
         # compatibility with 'func.__defaults__'
         defaults = None
 
-    return inspect.FullArgSpec(args, varargs, varkw, defaults,  # type: ignore
+    return inspect.FullArgSpec(args, varargs, varkw, defaults,
                                kwonlyargs, kwdefaults, annotations)
 
 
@@ -250,7 +250,7 @@ def object_description(object):
     except Exception:
         raise ValueError
     if isinstance(s, binary_type):
-        s = force_decode(s, None)  # type: ignore
+        s = force_decode(s, None)
     # Strip non-deterministic memory addresses such as
     # ``<__main__.A at 0x7f68cb685710>``
     s = memory_address_re.sub('', s)
@@ -310,7 +310,7 @@ class Signature:
         self.partialmethod_with_noargs = False
 
         try:
-            self.signature = inspect.signature(subject)  # type: ignore
+            self.signature = inspect.signature(subject)
         except IndexError:
             # Until python 3.6.4, cpython has been crashed on inspection for
             # partialmethods not having any arguments.
@@ -322,7 +322,7 @@ class Signature:
                 raise
 
         try:
-            self.annotations = typing.get_type_hints(subject)  # type: ignore
+            self.annotations = typing.get_type_hints(subject)
         except Exception:
             # get_type_hints() does not support some kind of objects like partial,
             # ForwardRef and so on.  For them, it raises an exception. In that case,
@@ -357,7 +357,7 @@ class Signature:
             if self.has_retval:
                 return self.signature.return_annotation
             else:
-                return inspect.Parameter.empty  # type: ignore
+                return inspect.Parameter.empty
         else:
             return None
 
@@ -394,10 +394,10 @@ class Signature:
                 if param.default is not param.empty:
                     if param.annotation is param.empty:
                         arg.write('=')
-                        arg.write(object_description(param.default))  # type: ignore
+                        arg.write(object_description(param.default))
                     else:
                         arg.write(' = ')
-                        arg.write(object_description(param.default))  # type: ignore
+                        arg.write(object_description(param.default))
             elif param.kind == param.VAR_POSITIONAL:
                 arg.write('*')
                 arg.write(param.name)
@@ -408,7 +408,7 @@ class Signature:
             args.append(arg.getvalue())
             last_kind = param.kind
 
-        if self.return_annotation is inspect.Parameter.empty:  # type: ignore
+        if self.return_annotation is inspect.Parameter.empty:
             return '(%s)' % ', '.join(args)
         else:
             if 'return' in self.annotations:
@@ -428,7 +428,7 @@ class Signature:
         Displaying complex types from ``typing`` relies on its private API.
         """
         if isinstance(annotation, string_types):
-            return annotation  # type: ignore
+            return annotation
         elif isinstance(annotation, typing.TypeVar):  # type: ignore
             return annotation.__name__
         elif not annotation:

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -26,7 +26,7 @@ from sphinx.util.pycompat import NoneType
 
 if False:
     # For type annotation
-    from typing import Any, Callable, Dict, List, Tuple, Type  # NOQA
+    from typing import Any, Callable, List, Mapping, Tuple, Type  # NOQA
 
 logger = logging.getLogger(__name__)
 
@@ -344,7 +344,7 @@ class Signature:
 
     @property
     def parameters(self):
-        # type: () -> Dict
+        # type: () -> Mapping
         if self.partialmethod_with_noargs:
             return {}
         else:

--- a/sphinx/util/jsdump.py
+++ b/sphinx/util/jsdump.py
@@ -57,7 +57,7 @@ def encode_string(s):
                 s1 = 0xd800 | ((n >> 10) & 0x3ff)
                 s2 = 0xdc00 | (n & 0x3ff)
                 return '\\u%04x\\u%04x' % (s1, s2)
-    return '"' + str(ESCAPE_ASCII.sub(replace, s)) + '"'  # type: ignore
+    return '"' + str(ESCAPE_ASCII.sub(replace, s)) + '"'
 
 
 def decode_string(s):
@@ -108,7 +108,7 @@ def dumps(obj, key=False):
     elif isinstance(obj, (tuple, list)):
         return '[%s]' % ','.join(dumps(x) for x in obj)
     elif isinstance(obj, string_types):
-        return encode_string(obj)  # type: ignore
+        return encode_string(obj)
     raise TypeError(type(obj))
 
 

--- a/sphinx/util/logging.py
+++ b/sphinx/util/logging.py
@@ -453,7 +453,7 @@ class MessagePrefixFilter(logging.Filter):
     def filter(self, record):
         # type: (logging.LogRecord) -> bool
         if self.prefix:
-            record.msg = self.prefix + ' ' + record.msg  # type: ignore
+            record.msg = self.prefix + ' ' + record.msg
         return True
 
 
@@ -525,7 +525,7 @@ class ColorizeFormatter(logging.Formatter):
             color = COLOR_MAP.get(record.levelno)
 
         if color:
-            return colorize(color, message)  # type: ignore
+            return colorize(color, message)
         else:
             return message
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -423,16 +423,16 @@ def make_refnode(builder, fromdocname, todocname, targetid, child, title=None):
     """Shortcut to create a reference node."""
     node = nodes.reference('', '', internal=True)
     if fromdocname == todocname and targetid:
-        node['refid'] = targetid  # type:ignore
+        node['refid'] = targetid
     else:
         if targetid:
-            node['refuri'] = (builder.get_relative_uri(fromdocname, todocname) +  # type:ignore
+            node['refuri'] = (builder.get_relative_uri(fromdocname, todocname) +
                               '#' + targetid)
         else:
-            node['refuri'] = builder.get_relative_uri(fromdocname, todocname)  # type:ignore
+            node['refuri'] = builder.get_relative_uri(fromdocname, todocname)
     if title:
-        node['reftitle'] = title  # type:ignore
-    node.append(child)  # type: ignore
+        node['reftitle'] = title
+    node.append(child)
     return node
 
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -423,15 +423,15 @@ def make_refnode(builder, fromdocname, todocname, targetid, child, title=None):
     """Shortcut to create a reference node."""
     node = nodes.reference('', '', internal=True)
     if fromdocname == todocname and targetid:
-        node['refid'] = targetid
+        node['refid'] = targetid  # type:ignore
     else:
         if targetid:
-            node['refuri'] = (builder.get_relative_uri(fromdocname, todocname) +
+            node['refuri'] = (builder.get_relative_uri(fromdocname, todocname) +  # type:ignore
                               '#' + targetid)
         else:
-            node['refuri'] = builder.get_relative_uri(fromdocname, todocname)
+            node['refuri'] = builder.get_relative_uri(fromdocname, todocname)  # type:ignore
     if title:
-        node['reftitle'] = title
+        node['reftitle'] = title  # type:ignore
     node.append(child)  # type: ignore
     return node
 

--- a/sphinx/util/nodes.py
+++ b/sphinx/util/nodes.py
@@ -432,7 +432,7 @@ def make_refnode(builder, fromdocname, todocname, targetid, child, title=None):
             node['refuri'] = builder.get_relative_uri(fromdocname, todocname)
     if title:
         node['reftitle'] = title
-    node.append(child)
+    node.append(child)  # type: ignore
     return node
 
 

--- a/sphinx/util/osutil.py
+++ b/sphinx/util/osutil.py
@@ -168,9 +168,9 @@ def ustrftime(format, *args):
     # On Windows, time.strftime() and Unicode characters will raise UnicodeEncodeError.
     # https://bugs.python.org/issue8304
     try:
-        return time.strftime(format, *args)  # type: ignore
+        return time.strftime(format, *args)
     except UnicodeEncodeError:
-        r = time.strftime(format.encode('unicode-escape').decode(), *args)  # type: ignore
+        r = time.strftime(format.encode('unicode-escape').decode(), *args)
         return r.encode().decode('unicode-escape')
 
 
@@ -199,7 +199,7 @@ def abspath(pathdir):
         try:
             pathdir = pathdir.decode(fs_encoding)
         except UnicodeDecodeError:
-            raise UnicodeDecodeError('multibyte filename not supported on '  # type: ignore
+            raise UnicodeDecodeError('multibyte filename not supported on '
                                      'this filesystem encoding '
                                      '(%r)' % fs_encoding)
     return pathdir

--- a/sphinx/util/pycompat.py
+++ b/sphinx/util/pycompat.py
@@ -12,7 +12,7 @@
 import sys
 from html import escape as htmlescape  # NOQA
 from io import TextIOWrapper  # NOQA
-from textwrap import indent  # type: ignore # NOQA
+from textwrap import indent  # NOQA
 
 from six import text_type, exec_
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ description =
     Run type checks.
 deps =
     mypy
+    docutils-stubs
 commands=
     mypy sphinx/
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,6 @@ description =
     Run type checks.
 deps =
     mypy
-    docutils-stubs
 commands=
     mypy sphinx/
 


### PR DESCRIPTION
Subject: Resolve errors from type checking

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Resolve errors from type checking
- docutils-stubs installed, Python 3.7

### Detail
- Delete unused "type: ignore" 
- Fix return type of bytes method in `path` class (str -> bytes) 
- Fix the type of the second argument of get_lvar_names function in `parser` module

(Edit)
- Type specific_docroles explicitly
- Suppress typing errors by specifying "type: ignore"
- Fix wrong type declarations

### Relates
- N/A
