### PR TITLE
synchronize napoleon rst and python docs

### DIFF
--- a/doc/usage/extensions/autodoc.rst
+++ b/doc/usage/extensions/autodoc.rst
@@ -437,9 +437,14 @@ There are also config values that you can set:
    following values:
 
    * ``'signature'`` -- Show typehints as its signature (default)
+   * ``'description'`` -- Inject ``:type:`` and ``:rtype:`` annotations into the
+     documentation string.
    * ``'none'`` -- Do not show typehints
 
    .. versionadded:: 2.1
+
+   .. versionchanged:: 2.4
+      Added ``'description'`` capability.
 
 .. confval:: autodoc_warningiserror
 

--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -491,7 +491,7 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
    The entries can either be strings or tuples, depending on the intention:
      * To create a custom "generic" section, just pass a string.
      * To create an alias for an existing section, pass a tuple containing the
-   alias name and the original, in that order.
+       alias name and the original, in that order.
 
    If an entry is just a string, it is interpreted as a header for a generic
    section. If the entry is a tuple/list/indexed container, the first entry

--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -265,13 +265,16 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
     napoleon_numpy_docstring = True
     napoleon_include_init_with_doc = False
     napoleon_include_private_with_doc = False
-    napoleon_include_special_with_doc = True
+    napoleon_include_special_with_doc = False
     napoleon_use_admonition_for_examples = False
     napoleon_use_admonition_for_notes = False
     napoleon_use_admonition_for_references = False
     napoleon_use_ivar = False
     napoleon_use_param = True
     napoleon_use_rtype = True
+    napoleon_use_keyword = True
+    napoleon_custom_sections = None
+    napoleon_numpy_returns_no_rtype = False
 
 .. _Google style:
    https://google.github.io/styleguide/pyguide.html
@@ -298,9 +301,9 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
    **If True**::
 
        def __init__(self):
-           \"\"\"
+           """
            This will be included in the docs because it has a docstring
-           \"\"\"
+           """
 
        def __init__(self):
            # This will NOT be included in the docs
@@ -327,7 +330,7 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
 
    True to include special members (like ``__membername__``) with
    docstrings in the documentation. False to fall back to Sphinx's
-   default behavior. *Defaults to True.*
+   default behavior. *Defaults to False.*
 
    **If True**::
 
@@ -449,10 +452,11 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
    keywords.
    *Defaults to True.*
 
-   This behaves similarly to  :attr:`napoleon_use_param`. Note unlike docutils,
-   ``:keyword:`` and ``:param:`` will not be treated the same way - there will
-   be a separate "Keyword Arguments" section, rendered in the same fashion as
-   "Parameters" section (type links created if possible)
+   This behaves similarly to  :attr:`napoleon_use_param`. Note unlike
+   docutils, ``:keyword:`` and ``:param:`` will not be treated the same
+   way - there will be a separate "Keyword Arguments" section, rendered
+   in the same fashion as "Parameters" section (type links created if
+   possible)
 
    .. seealso::
 
@@ -478,3 +482,17 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
    **If False**::
 
        :returns: *bool* -- True if successful, False otherwise
+
+.. confval:: napoleon_custom_sections
+
+   Add a list of custom sections to include, expanding the list of parsed sections.
+   *Defaults to None.*
+
+   The entries can either be strings or tuples, depending on the intention:
+     * To create a custom "generic" section, just pass a string.
+     * To create an alias for an existing section, pass a tuple containing the
+   alias name and the original, in that order.
+
+   If an entry is just a string, it is interpreted as a header for a generic
+   section. If the entry is a tuple/list/indexed container, the first entry
+   is the name of the section, the second is the section key to emulate.

--- a/doc/usage/extensions/napoleon.rst
+++ b/doc/usage/extensions/napoleon.rst
@@ -203,6 +203,9 @@ One benefit of expressing types according to `PEP 484`_ is that
 type checkers and IDEs can take advantage of them for static code
 analysis.
 
+Google Style
+************
+
 Google style with Python 3 type annotations::
 
     def func(arg1: int, arg2: str) -> bool:
@@ -247,6 +250,42 @@ Google style with types in docstrings::
 .. _Python 2/3 compatible annotations:
    https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code
 
+NumPy Style
+***********
+
+NumPy style users may set :confval:`autodoc_typehints` to ``'description'`` in
+``conf.py`` to let the :mod:`autodoc <sphinx.ext.autodoc>` extension populate
+the type annotations. Simply omit the type annotation:
+
+.. code-block:: diff
+
+     Parameters
+     ----------
+   - arg1 : int
+   + arg1
+         Description of arg1
+   - arg2 : str
+   + arg2
+         Description of arg2
+
+.. note::
+
+   Values specified in the docstring take precedence over
+   :confval:`autodoc_typehints`.
+
+   .. code-block:: python3
+
+      def foo(arg: int):
+          """Summary line.
+
+          Parameters
+          ----------
+          arg : str
+              This will be documented as type ``str``, not ``int``.
+          """
+
+For automatic return types, the NumPy format must be changed by setting
+:confval:`napoleon_numpy_returns_no_rtype` to ``True`` in ``conf.py``.
 
 Configuration
 -------------
@@ -496,3 +535,36 @@ sure that "sphinx.ext.napoleon" is enabled in `conf.py`::
    If an entry is just a string, it is interpreted as a header for a generic
    section. If the entry is a tuple/list/indexed container, the first entry
    is the name of the section, the second is the section key to emulate.
+
+.. confval:: napoleon_numpy_returns_no_rtype
+
+   *Defaults to False.*
+   Traditional `NumPy style`_ requires the return type and a description
+   provided indented underneath::
+
+       Returns
+       -------
+       bool
+           A description of the return.
+       int
+           A different description for a different possible return.
+
+   This style affords the ability to document multiple return types, but
+   the formatting rules inherently prohibit omitting the return type.  If
+   using :confval:`autodoc_typehints` as ``'description'``, and setting
+   this configuration value to ``True``, a user may omit the return type:
+
+   .. code-block:: diff
+
+        Returns
+        -------
+      + A description of the return.
+      - bool
+      -     A description of the return.
+
+   As python function signatures may only have one return type annotation,
+   setting this value to True implies only one return type is being
+   documented.
+
+   .. versionadded:: 2.4
+   .. seealso:: `Type Annotations`_.

--- a/sphinx/ext/napoleon/__init__.py
+++ b/sphinx/ext/napoleon/__init__.py
@@ -41,6 +41,7 @@ class Config:
         napoleon_use_rtype = True
         napoleon_use_keyword = True
         napoleon_custom_sections = None
+        napoleon_numpy_returns_no_rtype = False
 
     .. _Google style:
        https://google.github.io/styleguide/pyguide.html
@@ -247,7 +248,37 @@ class Config:
         section. If the entry is a tuple/list/indexed container, the first entry
         is the name of the section, the second is the section key to emulate.
 
+    napoleon_numpy_returns_no_rtype : :obj:`bool` (Defaults to False)
+        Traditional `NumPy style`_ requires the return type and a description
+        provided indented underneath::
 
+            Returns
+            -------
+            bool
+                A description of the return.
+            int
+                A different description for a different possible return.
+
+        This style affords the ability to document multiple return types, but
+        the formatting rules inherently prohibit omitting the return type.  If
+        using :confval:`autodoc_typehints` as ``'description'``, and setting
+        this configuration value to ``True``, a user may omit the return type:
+
+        .. code-block:: diff
+
+             Returns
+             -------
+           + A description of the return.
+           - bool
+           -     A description of the return.
+
+        As python function signatures may only have one return type annotation,
+        setting this value to True implies only one return type is being
+        documented.
+
+        .. versionadded:: 2.4
+
+        .. seealso:: `Type Annotations`_.
     """
     _config_values = {
         'napoleon_google_docstring': (True, 'env'),
@@ -262,7 +293,8 @@ class Config:
         'napoleon_use_param': (True, 'env'),
         'napoleon_use_rtype': (True, 'env'),
         'napoleon_use_keyword': (True, 'env'),
-        'napoleon_custom_sections': (None, 'env')
+        'napoleon_custom_sections': (None, 'env'),
+        'napoleon_numpy_returns_no_rtype': (False, 'env')
     }
 
     def __init__(self, **settings: Any) -> None:

--- a/sphinx/ext/napoleon/docstring.py
+++ b/sphinx/ext/napoleon/docstring.py
@@ -887,7 +887,16 @@ class NumpyDocstring(GoogleDocstring):
         return _name, _type, _desc
 
     def _consume_returns_section(self) -> List[Tuple[str, str, List[str]]]:
-        return self._consume_fields(prefer_type=True)
+        # Default is False, consume fields like normal.
+        # Otherwise, simply return the whole Returns section unchanged.
+        if not self._config.napoleon_numpy_returns_no_rtype:
+            return self._consume_fields(prefer_type=True)
+        else:
+            self._consume_empty()
+            desc_lines = []
+            while not self._is_section_break():
+                desc_lines.append(next(self._line_iter))
+            return [('', '', desc_lines)]
 
     def _consume_section_header(self) -> str:
         section = next(self._line_iter)


### PR DESCRIPTION
* napoleon_include_special_with_doc defaults have changed
* add documentation for napoleon_custom_sections

-------------------

Docs are slightly out of sync, I copy-pasted and reformatted as things were.  Only deviation was

1. Remove `\"` in one place (needed in python docs, not rst).
2. Seems that somebody re-flowed `napoleon_use_keyword` docs when converting pydocs to rst.  It only affects one paragraph, so I "undid" that to avoid diffs in future.

