### PR TITLE
Remove additional mentions of Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         'pytest',
         'pytest-cov',
         'html5lib',
-        'typed_ast',  # for py35-37
+        'typed_ast',  # for py36-37
         'cython',
     ],
 }

--- a/sphinx/pycode/parser.py
+++ b/sphinx/pycode/parser.py
@@ -10,7 +10,6 @@
 import inspect
 import itertools
 import re
-import sys
 import tokenize
 from collections import OrderedDict
 from inspect import Signature

--- a/sphinx/util/inspect.py
+++ b/sphinx/util/inspect.py
@@ -271,7 +271,7 @@ def is_singledispatch_method(obj: Any) -> bool:
     try:
         from functools import singledispatchmethod  # type: ignore
         return isinstance(obj, singledispatchmethod)
-    except ImportError:  # py35-37
+    except ImportError:  # py36-37
         return False
 
 

--- a/sphinx/util/typing.py
+++ b/sphinx/util/typing.py
@@ -22,7 +22,7 @@ else:
     from typing import _ForwardRef  # type: ignore
 
     class ForwardRef:
-        """A pseudo ForwardRef class for py35 and py36."""
+        """A pseudo ForwardRef class for py36."""
         def __init__(self, arg: Any, is_argument: bool = True) -> None:
             self.arg = arg
 


### PR DESCRIPTION
A couple more occurrences of Python 3.5 that can be cleaned up :slightly_smiling_face:.